### PR TITLE
Corrected Link to Open Encyclopedia Slides

### DIFF
--- a/_includes/daily/04.markdown
+++ b/_includes/daily/04.markdown
@@ -10,7 +10,7 @@ Thu, 2/1
 <div class="column_materials">
 <p markdown="block">
 
-[Open Encyclopedia](slides/week3/open_encyclopedia.html)  
+[Open Encyclopedia](slides/week2/open_encyclopedia.html)  
 
 - discussion about Tom's presentation
 - reflections about _The Catherdral and The Bazaar_


### PR DESCRIPTION
I changed 'slides/week3/open_encyclopedia.html' to 'slides/week2/open_encyclopedia.html'. The Open Encyclopedia slides in the websites Github are in week2. 

This pull request refers to [Issue #8](https://github.com/joannakl/cs480_s18/issues/8).

Please help me verify that this is the intended fix to this issue @dazigemm.