### PR TITLE
Fixed issue #20: Spacing error in list of bullet points covered

### DIFF
--- a/syllabus.markdown
+++ b/syllabus.markdown
@@ -59,14 +59,11 @@ You are expected to know and remember the material from CSCI.UA.0101 and CSCI.UA
 - Linux and Linux based tools for software development 
 
 - Case studies of several open source projects
-
-<!-- 
     - small scale, single program projects (possibly humanitarian free open source projects - HFOSS)
 	- Mozilla software suit 
 	- Eclipse
 	- large scale, multi program projects (example OpenMRS, Sakai) 
---> 
-
+    
 - Licensing
     - types of licenses available and what is allowed
     - how to licenses your own work


### PR DESCRIPTION
There seemed to be an extra space between two bullet points under "List of Topics Covered" and in the syllabus.markdown it seemed that a section with additional bullet points that were commented out, so I uncommented it. 