### PR TITLE
fixed class meeting location

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@ course_number: "CSCI-UA 480"
 course_name: "Open Source Software Development" 
 course_section: "010"
 course_semester: "Spring 2017"
-course_time: "<br>Tuesdays and Thursdays 11:00am - 12:15pm, CIWW, Room C10<br>"
+course_time: "<br>Tuesdays and Thursdays 11:00am - 12:15pm, 60 5th ave, Room C10<br>"
 
 
 


### PR DESCRIPTION
The class location was listed as being in CIWW, so I corrected the error by putting our actual class location (60 5th ave).