### PR TITLE
Fixed issue #13: Incorrect Link to Daily from Syllabus

### DIFF
--- a/syllabus.markdown
+++ b/syllabus.markdown
@@ -1,11 +1,11 @@
 ---
-layout: default 
+layout: default
 ---
 
 
-# Textbook(s) 
+# Textbook(s)
 
---- 
+---
 
 <!--
 |<img src="{{site.book_required_image}}" name="Book" border="0px" width="120px">| **[{{ site.book_required }}]( {{ site.book_required_link }})** {{ site.book_required_edition }}<br> {{ site.book_required_author }} <br> {{ site.book_required_note }}  |
@@ -18,14 +18,14 @@ layout: default
 |<img src="{{site.book_opt_5_image}}" name="Book" border="0px" width="120px">| **[{{ site.book_opt_5 }}]( {{ site.book_opt_5_link }})** {{ site.book_opt_5_edition }}<br> {{ site.book_opt_5_author }} <br> {{ site.book_opt_5_note }}  |
 
 
-# Open Source _News Sites_ 
+# Open Source _News Sites_
 
-- [OpenSource.com](https://opensource.com/) 
-   
-- [OpenHealthNews.com](http://www.openhealthnews.com/) 
-   
-- [OpenSourceForU](http://opensourceforu.com/) 
-     
+- [OpenSource.com](https://opensource.com/)
+
+- [OpenHealthNews.com](http://www.openhealthnews.com/)
+
+- [OpenSourceForU](http://opensourceforu.com/)
+
 
 ---
 # Prerequisites
@@ -36,36 +36,36 @@ You are expected to know and remember the material from CSCI.UA.0101 and CSCI.UA
 
 
 # Topics Covered (exact list of topics subject to change by the beginning of the spring semester)
---- 
+---
 
 - Intro to open source: it's not only code
 	- open data,
 	- open hardware,
 	- open education,
 	- open government
-    - open health 
-	- ... 
+    - open health
+	- ...
 - History and philosophy of open source
 
-- How to be a Fosser? 
+- How to be a Fosser?
     - types of contributions
-    - how to get involved 
+    - how to get involved
 - Review of tools commonly used in open source projects
 	- version control
 	- communication: IRC as a meeting platform, mailing lists, wikis/blogs
-    - bug and issue trackers 
+    - bug and issue trackers
     - documentation
-    - collaborative development 
-- Linux and Linux based tools for software development 
+    - collaborative development
+- Linux and Linux based tools for software development
 
 - Case studies of several open source projects
 
-<!-- 
+<!--
     - small scale, single program projects (possibly humanitarian free open source projects - HFOSS)
-	- Mozilla software suit 
+	- Mozilla software suit
 	- Eclipse
-	- large scale, multi program projects (example OpenMRS, Sakai) 
---> 
+	- large scale, multi program projects (example OpenMRS, Sakai)
+-->
 
 - Licensing
     - types of licenses available and what is allowed
@@ -73,21 +73,21 @@ You are expected to know and remember the material from CSCI.UA.0101 and CSCI.UA
     - avoiding plagiarism
 
 
-For detailed schedule, see the [Daily](syllabus.html) tab of this page.
+For detailed schedule, see the [Daily](daily.html) tab of this page.
 
 
 
 
 # Grading  (exact grading rule subject to change by the beginning of the spring semester)
---- 
+---
 
-Your grade will be based on: 
+Your grade will be based on:
 
-* exams and quizzes (50%): pop-quizzes (5%), one midterm exam (200%) and the final (25%),  
+* exams and quizzes (50%): pop-quizzes (5%), one midterm exam (200%) and the final (25%),
 * contributions and homeworks (40%): these include contributions to existing open source projects (details to be discussed at the
-beginning of the semester)  
+beginning of the semester)
 * participation (10%): weekly posts about contributions and activities, in class discussions and presentations
- 
+
 
 Grades will be determined using the following scale:
 
@@ -102,57 +102,57 @@ Grades will be determined using the following scale:
         F 	less than 65
 
 
-The grade of *Incomplete* is reserved for students who, for legitimate and documented reason, miss the final exam. The grade of *Incomplete* **will not be given** to student who started falling behind in class. Those students should withdraw from the class or switch to *Pass/Fail* option. 
-		
+The grade of *Incomplete* is reserved for students who, for legitimate and documented reason, miss the final exam. The grade of *Incomplete* **will not be given** to student who started falling behind in class. Those students should withdraw from the class or switch to *Pass/Fail* option.
+
 
 # EXAMS
 ---
-There will be a midterm and a final exam. All exams are cumulative. 
+There will be a midterm and a final exam. All exams are cumulative.
 
 __Missing an exam:__ There will be no make-up exams. Failure to take an exam counts as a zero grade on that exam. The only exception to this rule is for students who have a legitimate medical or personal emergency (documented). These students need to talk to the instructor as soon as possible (trying to excuse an exam absence a week after it happened will not work).
 
 
 # Academic Integrity Policy
---- 
+---
 
-I follow the department's 
-[academic integrity rules](http://cs.nyu.edu/webapps/content/academic/undergrad/academic_integrity). 
+I follow the department's
+[academic integrity rules](http://cs.nyu.edu/webapps/content/academic/undergrad/academic_integrity).
 
-The nature of open source is based on collaborative work. But that work is still performed by individuals. 
-Your name should not be associated with a contribution that is not your own or that you have not put significant amount 
-of work into. 
+The nature of open source is based on collaborative work. But that work is still performed by individuals.
+Your name should not be associated with a contribution that is not your own or that you have not put significant amount
+of work into.
 
 
 
 # Academic Email Etiquette
---- 
+---
 
-* Check the school email address on a regular basis. You can simply forward its content 
+* Check the school email address on a regular basis. You can simply forward its content
 to another email account that you use regularly.
- 
-* Use your school's email account to send emails to professors, instructors, TA's, graders, 
-administrators, etc. OR make sure that your email address contains your true name, 
-not "frabjous@gmail.com", "BabyGurl@yahoo.com" or some other cool alias. 
- 
-* Start your email with proper salutations! Use the correct titles (Professor, Dr., etc.) 
-and spell first and last names correctly. If you are on the first name basis with your instructors, 
-use their names, not "Hey". For example: "Dear Professor Drummer" or "Dear Robert", not "Hey Bob". 
- 
+
+* Use your school's email account to send emails to professors, instructors, TA's, graders,
+administrators, etc. OR make sure that your email address contains your true name,
+not "frabjous@gmail.com", "BabyGurl@yahoo.com" or some other cool alias.
+
+* Start your email with proper salutations! Use the correct titles (Professor, Dr., etc.)
+and spell first and last names correctly. If you are on the first name basis with your instructors,
+use their names, not "Hey". For example: "Dear Professor Drummer" or "Dear Robert", not "Hey Bob".
+
 * Sign your name under the body of your email, otherwise you expect people to read emails from anonymous.
- 
+
 * Do not write everything in upper-case letters. Do not write everything in lower-case letters.
- 
-* Make sure you included everything you wanted before hitting send. Don't send three emails 
-one after another because you forgot something in the first one. 
- 
-* Proofread the text in your email before sending it. Most of the email clients check for 
+
+* Make sure you included everything you wanted before hitting send. Don't send three emails
+one after another because you forgot something in the first one.
+
+* Proofread the text in your email before sending it. Most of the email clients check for
 typos, but they cannot tell if your email makes much sense. Read it, before you send it.
- 
+
 
 
 <br>
 <br>
-        
-        
-        
-        
+
+
+
+

--- a/syllabus.markdown
+++ b/syllabus.markdown
@@ -1,11 +1,11 @@
 ---
-layout: default
+layout: default 
 ---
 
 
-# Textbook(s)
+# Textbook(s) 
 
----
+--- 
 
 <!--
 |<img src="{{site.book_required_image}}" name="Book" border="0px" width="120px">| **[{{ site.book_required }}]( {{ site.book_required_link }})** {{ site.book_required_edition }}<br> {{ site.book_required_author }} <br> {{ site.book_required_note }}  |
@@ -18,14 +18,14 @@ layout: default
 |<img src="{{site.book_opt_5_image}}" name="Book" border="0px" width="120px">| **[{{ site.book_opt_5 }}]( {{ site.book_opt_5_link }})** {{ site.book_opt_5_edition }}<br> {{ site.book_opt_5_author }} <br> {{ site.book_opt_5_note }}  |
 
 
-# Open Source _News Sites_
+# Open Source _News Sites_ 
 
-- [OpenSource.com](https://opensource.com/)
-
-- [OpenHealthNews.com](http://www.openhealthnews.com/)
-
-- [OpenSourceForU](http://opensourceforu.com/)
-
+- [OpenSource.com](https://opensource.com/) 
+   
+- [OpenHealthNews.com](http://www.openhealthnews.com/) 
+   
+- [OpenSourceForU](http://opensourceforu.com/) 
+     
 
 ---
 # Prerequisites
@@ -36,36 +36,36 @@ You are expected to know and remember the material from CSCI.UA.0101 and CSCI.UA
 
 
 # Topics Covered (exact list of topics subject to change by the beginning of the spring semester)
----
+--- 
 
 - Intro to open source: it's not only code
-	- open data,
-	- open hardware,
-	- open education,
-	- open government
-    - open health
-	- ...
+    - open data,
+    - open hardware,
+    - open education,
+    - open government
+    - open health 
+    - ... 
 - History and philosophy of open source
 
-- How to be a Fosser?
+- How to be a Fosser? 
     - types of contributions
-    - how to get involved
+    - how to get involved 
 - Review of tools commonly used in open source projects
-	- version control
-	- communication: IRC as a meeting platform, mailing lists, wikis/blogs
-    - bug and issue trackers
+    - version control
+    - communication: IRC as a meeting platform, mailing lists, wikis/blogs
+    - bug and issue trackers 
     - documentation
-    - collaborative development
-- Linux and Linux based tools for software development
+    - collaborative development 
+- Linux and Linux based tools for software development 
 
 - Case studies of several open source projects
 
-<!--
+<!-- 
     - small scale, single program projects (possibly humanitarian free open source projects - HFOSS)
-	- Mozilla software suit
-	- Eclipse
-	- large scale, multi program projects (example OpenMRS, Sakai)
--->
+    - Mozilla software suit 
+    - Eclipse
+    - large scale, multi program projects (example OpenMRS, Sakai) 
+--> 
 
 - Licensing
     - types of licenses available and what is allowed
@@ -79,80 +79,80 @@ For detailed schedule, see the [Daily](daily.html) tab of this page.
 
 
 # Grading  (exact grading rule subject to change by the beginning of the spring semester)
----
+--- 
 
-Your grade will be based on:
+Your grade will be based on: 
 
-* exams and quizzes (50%): pop-quizzes (5%), one midterm exam (200%) and the final (25%),
+* exams and quizzes (50%): pop-quizzes (5%), one midterm exam (200%) and the final (25%),  
 * contributions and homeworks (40%): these include contributions to existing open source projects (details to be discussed at the
-beginning of the semester)
+beginning of the semester)  
 * participation (10%): weekly posts about contributions and activities, in class discussions and presentations
-
+ 
 
 Grades will be determined using the following scale:
 
-        A 	95-100
-        A- 	90-95
-        B+ 	87-90
-        B 	83-87
-        B- 	80-83
-        C+ 	76-80
-        C 	72-76
-        D 	65-72
-        F 	less than 65
+        A   95-100
+        A-  90-95
+        B+  87-90
+        B   83-87
+        B-  80-83
+        C+  76-80
+        C   72-76
+        D   65-72
+        F   less than 65
 
 
-The grade of *Incomplete* is reserved for students who, for legitimate and documented reason, miss the final exam. The grade of *Incomplete* **will not be given** to student who started falling behind in class. Those students should withdraw from the class or switch to *Pass/Fail* option.
-
+The grade of *Incomplete* is reserved for students who, for legitimate and documented reason, miss the final exam. The grade of *Incomplete* **will not be given** to student who started falling behind in class. Those students should withdraw from the class or switch to *Pass/Fail* option. 
+        
 
 # EXAMS
 ---
-There will be a midterm and a final exam. All exams are cumulative.
+There will be a midterm and a final exam. All exams are cumulative. 
 
 __Missing an exam:__ There will be no make-up exams. Failure to take an exam counts as a zero grade on that exam. The only exception to this rule is for students who have a legitimate medical or personal emergency (documented). These students need to talk to the instructor as soon as possible (trying to excuse an exam absence a week after it happened will not work).
 
 
 # Academic Integrity Policy
----
+--- 
 
-I follow the department's
-[academic integrity rules](http://cs.nyu.edu/webapps/content/academic/undergrad/academic_integrity).
+I follow the department's 
+[academic integrity rules](http://cs.nyu.edu/webapps/content/academic/undergrad/academic_integrity). 
 
-The nature of open source is based on collaborative work. But that work is still performed by individuals.
-Your name should not be associated with a contribution that is not your own or that you have not put significant amount
-of work into.
+The nature of open source is based on collaborative work. But that work is still performed by individuals. 
+Your name should not be associated with a contribution that is not your own or that you have not put significant amount 
+of work into. 
 
 
 
 # Academic Email Etiquette
----
+--- 
 
-* Check the school email address on a regular basis. You can simply forward its content
+* Check the school email address on a regular basis. You can simply forward its content 
 to another email account that you use regularly.
-
-* Use your school's email account to send emails to professors, instructors, TA's, graders,
-administrators, etc. OR make sure that your email address contains your true name,
-not "frabjous@gmail.com", "BabyGurl@yahoo.com" or some other cool alias.
-
-* Start your email with proper salutations! Use the correct titles (Professor, Dr., etc.)
-and spell first and last names correctly. If you are on the first name basis with your instructors,
-use their names, not "Hey". For example: "Dear Professor Drummer" or "Dear Robert", not "Hey Bob".
-
+ 
+* Use your school's email account to send emails to professors, instructors, TA's, graders, 
+administrators, etc. OR make sure that your email address contains your true name, 
+not "frabjous@gmail.com", "BabyGurl@yahoo.com" or some other cool alias. 
+ 
+* Start your email with proper salutations! Use the correct titles (Professor, Dr., etc.) 
+and spell first and last names correctly. If you are on the first name basis with your instructors, 
+use their names, not "Hey". For example: "Dear Professor Drummer" or "Dear Robert", not "Hey Bob". 
+ 
 * Sign your name under the body of your email, otherwise you expect people to read emails from anonymous.
-
+ 
 * Do not write everything in upper-case letters. Do not write everything in lower-case letters.
-
-* Make sure you included everything you wanted before hitting send. Don't send three emails
-one after another because you forgot something in the first one.
-
-* Proofread the text in your email before sending it. Most of the email clients check for
+ 
+* Make sure you included everything you wanted before hitting send. Don't send three emails 
+one after another because you forgot something in the first one. 
+ 
+* Proofread the text in your email before sending it. Most of the email clients check for 
 typos, but they cannot tell if your email makes much sense. Read it, before you send it.
-
+ 
 
 
 <br>
 <br>
-
-
-
-
+        
+        
+        
+        

--- a/syllabus.markdown
+++ b/syllabus.markdown
@@ -39,20 +39,20 @@ You are expected to know and remember the material from CSCI.UA.0101 and CSCI.UA
 --- 
 
 - Intro to open source: it's not only code
-    - open data,
-    - open hardware,
-    - open education,
-    - open government
+	- open data,
+	- open hardware,
+	- open education,
+	- open government
     - open health 
-    - ... 
+	- ... 
 - History and philosophy of open source
 
 - How to be a Fosser? 
     - types of contributions
     - how to get involved 
 - Review of tools commonly used in open source projects
-    - version control
-    - communication: IRC as a meeting platform, mailing lists, wikis/blogs
+	- version control
+	- communication: IRC as a meeting platform, mailing lists, wikis/blogs
     - bug and issue trackers 
     - documentation
     - collaborative development 
@@ -62,9 +62,9 @@ You are expected to know and remember the material from CSCI.UA.0101 and CSCI.UA
 
 <!-- 
     - small scale, single program projects (possibly humanitarian free open source projects - HFOSS)
-    - Mozilla software suit 
-    - Eclipse
-    - large scale, multi program projects (example OpenMRS, Sakai) 
+	- Mozilla software suit 
+	- Eclipse
+	- large scale, multi program projects (example OpenMRS, Sakai) 
 --> 
 
 - Licensing
@@ -91,19 +91,19 @@ beginning of the semester)
 
 Grades will be determined using the following scale:
 
-        A   95-100
-        A-  90-95
-        B+  87-90
-        B   83-87
-        B-  80-83
-        C+  76-80
-        C   72-76
-        D   65-72
-        F   less than 65
+        A 	95-100
+        A- 	90-95
+        B+ 	87-90
+        B 	83-87
+        B- 	80-83
+        C+ 	76-80
+        C 	72-76
+        D 	65-72
+        F 	less than 65
 
 
 The grade of *Incomplete* is reserved for students who, for legitimate and documented reason, miss the final exam. The grade of *Incomplete* **will not be given** to student who started falling behind in class. Those students should withdraw from the class or switch to *Pass/Fail* option. 
-        
+		
 
 # EXAMS
 ---


### PR DESCRIPTION
Fixed issue #13 - the incorrect link on the Syllabus page (bottom of the Topics Covered section). "Daily" now actually links to the Daily page instead of back to the syllabus. 🎉 

Feel free to squash my commits when this is merged - Sublime accidentally messed up some whitespace and indentation that took me a couple tries to get back to the way it was :)

You can see the fix in action at [my fork's Github Pages site](https://felixplajer.github.io/cs480_s18/syllabus.html).