### PR TITLE
Fix for issue #79. Bad link in class number 2

### DIFF
--- a/_includes/daily/02.markdown
+++ b/_includes/daily/02.markdown
@@ -16,7 +16,7 @@ Thu, 1/25
 
 
 
-[History of Open Source]()  
+[History of Open Source](slides/week1/history.html)  
 
 - [The Cathedral and the Bazaar](http://www.catb.org/~esr/writings/cathedral-bazaar/cathedral-bazaar/index.html) by Eric S Raymond <br>[PDF](http://www.unterstein.net/su/docs/CathBaz.pdf) 
 


### PR DESCRIPTION
Added link to slides on History of Open Source.