### PR TITLE
Issue #94: Fixed a typo in Syllabus

### DIFF
--- a/_includes/daily/NYC_OpenDataWeek.markdown
+++ b/_includes/daily/NYC_OpenDataWeek.markdown
@@ -11,7 +11,7 @@
 [NYC Open Data Week](https://www.open-data.nyc/), March 3-10 
 
 - attend at least two different events
-- in your blog describe the event (optional: post a selfie of yourself at the event, make sure that it is clear that you are at that event, alternative: email a the picture to Joanna) 
+- in your blog describe the event (optional: post a selfie of yourself at the event, make sure that it is clear that you are at that event, alternative: email a picture to Joanna) 
 
 
 


### PR DESCRIPTION
Removed "the" in cs480_s18/_includes/daily/NYC_OpenDataWeek.markdown in line 14.

This should fix issue #94. 