### PR TITLE
Fixed minor typos ("asses"->"assess", "team-mates -> "teammates' ", "…

### DIFF
--- a/_includes/daily/12.markdown
+++ b/_includes/daily/12.markdown
@@ -34,8 +34,8 @@ List of projects:
 <p markdown="block">
 
 Team assesment and plan:
-- Based on the team, what are the strenghts and weaknesses of the team in terms of
-being able to participate in the project you selected? (Use your team-mates blog posts to asses
+- Based on the team, what are the strengths and weaknesses of the team in terms of
+being able to participate in the project you selected? (Use your teammates' blog posts to assess
 their strengths and weaknesses)
 - Come up with a common meeting time (2 hours block outside of class) to which all
 team members can commit. Come up with an alternative meeting time (2 hours block outside of  


### PR DESCRIPTION
Original image with typos (Screenshot borrowed from Issue #95):
![Dora's Screenshot from Issue #95](https://user-images.githubusercontent.com/10905385/36882779-ed196980-1da3-11e8-8bef-e2916c570178.png)

Fixed minor typos, as detailed in [Issue #95](https://github.com/joannakl/cs480_s18/issues/95):
- "asses"->"assess"
- "team-mates -> "teammates' "
- "strenghts" -> "strengths" (first appearance of the word)

@dorasun When you have the chance to, please verify if this fix is adequate or not.

