### PR TITLE
Issue #99 (Fixed instruction for incorporating Contributions in blog)

### DIFF
--- a/_includes/daily/18.markdown
+++ b/_includes/daily/18.markdown
@@ -45,10 +45,10 @@ state what type of contribution in is: "course website", "Wikipedia", "Other".
 To incorporate this document into your blog, edit the `layouts/default.html` document
 and add
 
-`<a href="{{ site.baseurl }}/contributions">Contributions</a>`
+`<a href="``{```{ site.baseurl }```}``/contributions">Contributions</a>`
 
 after line
-31 (or after the line that contains the link to the About page, `<a href="{{ site.baseurl }}/about">About</a>`).
+31 (or after the line that contains the link to the About page, `<a href="``{```{ site.baseurl }```}``/about">About</a>`).
 
 <br>
 


### PR DESCRIPTION
This fixes #99 so that the correct instruction appears for incorporating Contributions in blogs (i.e. instead of `/cs480_s18`, `{{ site.baseurl }}` appears in the instruction). 

I did try the possible fix discussed in the issue comments (removing the spaces) but this didn't work. I found that inserting backticks instead both prevented it from actually grabbing cs480_s18 and kept the entire link formatted as code, although there may be a better way to fix this.

Please confirm the fix @juliandorville 